### PR TITLE
Update install.yml

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -48,6 +48,7 @@
     owner: "{% if tomcat_permissions_production %}root{% else %}{{ tomcat_user }}{% endif %}"
     group: "{{ tomcat_group }}"
     creates: "{{ tomcat_install_path }}/apache-tomcat-{{ tomcat_version }}"
+    copy: no
   register: tomcat_installed
   when: not is_installed.stat.exists
 


### PR DESCRIPTION
copy: no specifies that the file should no try and be copied from the local machine running the tasks. The previous task downloads the file to the remote machine.