### PR TITLE
Using setenv.sh and /etc/systemd/

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,14 @@ Some defaults (probably not requiring tampering):
 - `tomcat_group`: tomcat
 - `tomcat_listen_address`: 0.0.0.0
 - `tomcat_temp_download_path`: /tmp/ansibletomcattempdir
+- `tomcat_systemd_config_path`: /etc/systemd/system
 
 Custom templates for server.xml, users.xml, systemd service file, etc.:
 - In case the default templates don't suit your needs, you can use your own custom templates by changing the following variables:
   * `tomcat_template_server`
   * `tomcat_template_users`
   * `tomcat_template_systemd_service`
+  * `tomcat_template_setenv`
   * `tomcat_template_manager_context`
   * `tomcat_template_host_manager_context`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ tomcat_group: tomcat
 
 tomcat_install_path: /opt
 tomcat_service_name: tomcat
+tomcat_systemd_config_path: /etc/systemd/system/
 tomcat_jvm_memory_percentage_xms: 15
 tomcat_jvm_memory_percentage_xmx: 55
 
@@ -48,6 +49,7 @@ tomcat_user_roles: []
 tomcat_template_manager_context: "manager-context.xml.j2"
 tomcat_template_host_manager_context: "host-manager-context.xml.j2"
 tomcat_template_systemd_service: "tomcat.service.j2"
+tomcat_template_setenv: "tomcat.setenv.sh.j2"
 tomcat_template_server: "tomcat-server-{{ '.'.join(tomcat_version.split('.')[:2]) }}.xml.j2"
 tomcat_template_users: "tomcat-users-{{ '.'.join(tomcat_version.split('.')[:2]) }}.xml.j2"
 

--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -7,12 +7,12 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_tomcat_systemd_file(host):
-    f = host.file('/usr/lib/systemd/system/tomcat.service')
+    f = host.file('/etc/systemd/system/tomcat.service')
     assert f.exists
     assert f.is_file
     assert f.user == 'root'
     assert f.group == 'root'
-    assert f.contains('JAVA_HOME')
+    assert f.contains('CATALINA_HOME')
 
 
 def test_opt_tomcat(host):

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -52,7 +52,13 @@
 - name: Configure service file {{ tomcat_service_name }}.service
   template:
     src: "{{ tomcat_template_systemd_service }}"
-    dest: /usr/lib/systemd/system/{{ tomcat_service_name }}.service
+    dest: "{{ tomcat_systemd_config_path }}/{{ tomcat_service_name }}.service"
+  notify: restart tomcat
+
+- name: Configure setenv.sh
+  template:
+    src: "{{ tomcat_template_setenv }}"
+    dest: "{{ tomcat_install_path }}/{{ tomcat_service_name }}/bin/setenv.sh"
   notify: restart tomcat
 
 - name: Enable tomcat service on startup

--- a/templates/tomcat.service.j2
+++ b/templates/tomcat.service.j2
@@ -6,12 +6,8 @@ After=syslog.target network.target
 [Service]
 Type=forking
 
-Environment=JAVA_HOME={{ tomcat_java_home }}
-Environment=CATALINA_PID={{ tomcat_install_path }}/{{ tomcat_service_name }}/temp/tomcat.pid
 Environment=CATALINA_HOME={{ tomcat_install_path }}/{{ tomcat_service_name }}
 Environment=CATALINA_BASE={{ tomcat_install_path }}/{{ tomcat_service_name }}
-Environment='CATALINA_OPTS=-Xms{{ tomcat_jvm_memory_percentage_xms*ansible_memtotal_mb//100 }}M -Xmx{{ tomcat_jvm_memory_percentage_xmx*ansible_memtotal_mb//100 }}M -server -XX:+UseParallelGC {% if tomcat_debug_mode == True %}-Xdebug -Xrunjdwp:transport=dt_socket,address={{ tomcat_port_debug }},server=y,suspend=n{% endif %}'
-Environment='JAVA_OPTS=-Djava.awt.headless=true -Djava.security.egd=file:/dev/./urandom'
 
 ExecStart={{ tomcat_install_path }}/{{ tomcat_service_name }}/bin/startup.sh
 ExecStop={{ tomcat_install_path }}/{{ tomcat_service_name }}/bin/shutdown.sh

--- a/templates/tomcat.setenv.sh.j2
+++ b/templates/tomcat.setenv.sh.j2
@@ -1,0 +1,4 @@
+JAVA_HOME={{ tomcat_java_home }}
+JAVA_OPTS="-Djava.awt.headless=true -Djava.security.egd=file:/dev/./urandom"
+CATALINA_OPTS="-Xms{{ tomcat_jvm_memory_percentage_xms*ansible_memtotal_mb//100 }}M -Xmx{{ tomcat_jvm_memory_percentage_xmx*ansible_memtotal_mb//100 }}M -server -XX:+UseParallelGC {% if tomcat_debug_mode == True %}-Xdebug -Xrunjdwp:transport=dt_socket,address={{ tomcat_port_debug }},server=y,suspend=n{% endif %}"
+CATALINA_PID="{{ tomcat_install_path }}/{{ tomcat_service_name }}/temp/tomcat.pid"


### PR DESCRIPTION
First of all, thank you for your job! You saved me a lot of time :-)

I ask you to merge those fixes:

As stated in [tomcat official docs](http://tomcat.apache.org/tomcat-8.5-doc/RUNNING.txt
)
> The recommended place to specify these variables is a "setenv" script. See
> below.

Also, `/usr/lib/systemd/system` path should not be used because can be overwritten by installed packages. See [here](https://unix.stackexchange.com/a/367237/156245)