### PR TITLE
Update user setup to not log users/passwords

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -10,6 +10,7 @@
 - name: Set fact of user roles to be enabled
   set_fact:
     tomcat_user_roles: "{{ (tomcat_user_roles + item.roles.split(',')|list)|unique }}"
+  no_log: true
   with_items:
     - "{{ tomcat_users }}"
 


### PR DESCRIPTION
In my opinion users and passwords should not be logged to `stdout`. I noticed that my passwords were exposed in the Ansible log so decided to add this `no_log` to the appropriate task.